### PR TITLE
Add force_encoding to avoid errors with messages containing non-ASCII characters.

### DIFF
--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -16,7 +16,7 @@ module Kafka
     end
 
     def encode(message)
-      [message.magic].pack("C") + [message.calculate_checksum].pack("N") + message.payload.to_s
+      [message.magic].pack("C") + [message.calculate_checksum].pack("N") + message.payload.to_s.force_encoding(Encoding::ASCII_8BIT)
     end
 
     def encode_request(topic, partition, messages)

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require File.dirname(__FILE__) + '/spec_helper'
 
 describe Producer do
@@ -43,6 +44,13 @@ describe Producer do
         message = Kafka::Message.new()
         full_message = [message.magic].pack("C") + [message.calculate_checksum].pack("N") + message.payload.to_s
         @producer.encode(message).should eql(full_message)
+      end
+
+      it "should encode strings containing non-ASCII characters" do
+        message = Kafka::Message.new("ümlaut")
+        encoded = @producer.encode(message)
+        data = [encoded.size].pack("N") + encoded
+        Kafka::Message.parse_from(data).payload.force_encoding(Encoding::UTF_8).should eql("ümlaut")
       end
     end
 


### PR DESCRIPTION
Added force_encoding to avoid errors when sending messages containing non-ASCII characters. This would fix issue #1, albeit leaving the encoding decisions to the caller. An alternative would be to send the encoding as part of the message, and correctly decode it when parsing a message. I think it's fine to let the user handle encoding himself.
