### PR TITLE
Optimized message decoding

### DIFF
--- a/lib/kafka/message.rb
+++ b/lib/kafka/message.rb
@@ -21,6 +21,7 @@ module Kafka
   class Message
 
     MAGIC_IDENTIFIER_DEFAULT = 0
+    MESSAGE_HEADER_FORMAT = 'NCN'.freeze
 
     attr_accessor :magic, :checksum, :payload
 
@@ -39,11 +40,9 @@ module Kafka
     end
 
     def self.parse_from(binary)
-      size     = binary[0, 4].unpack("N").shift.to_i
-      magic    = binary[4, 1].unpack("C").shift
-      checksum = binary[5, 4].unpack("N").shift
+      size, magic, checksum = binary.unpack(MESSAGE_HEADER_FORMAT)
       payload  = binary[9, size] # 5 = 1 + 4 is Magic + Checksum
-      return Kafka::Message.new(payload, magic, checksum)
+      Kafka::Message.new(payload, magic, checksum)
     end
   end
 end


### PR DESCRIPTION
This patch roughly halves the time spent decoding messages. Instead of doing three #unpack calls it does just one, and the format string is now a constant.

Obviously this doesn't double the consumer performance, there's a lot of other overhead in just moving the bits around, but it's something.

There's a lot of string literals that could be moved into constants in the rest of the code, I think there's a potential for getting at least a 10% speed increase in just fixing that. Code that runs thousands of times per second should not use literal strings, they create way too much garbage (remember that in Ruby a literal string always creates a new object since strings are mutable -- this is a huge performance hog, especially in MRI). If you want I can send a patch for that too.
