### PR TITLE
Support messages with magic version 1

### DIFF
--- a/lib/kafka/message.rb
+++ b/lib/kafka/message.rb
@@ -14,14 +14,28 @@
 # limitations under the License.
 module Kafka
 
-  # A message. The format of an N byte message is the following:
-  # 1 byte "magic" identifier to allow format changes
-  # 4 byte CRC32 of the payload
-  # N - 5 byte payload
+  # A message. The format of a message is as follows:
+  #
+  # 4 byte big-endian int: length of message in bytes (including the rest of
+  #                        the header, but excluding the length field itself)
+  # 1 byte: "magic" identifier (format version number)
+  #
+  # If the magic byte == 0, there is one more header field:
+  #
+  # 4 byte big-endian int: CRC32 checksum of the payload
+  #
+  # If the magic byte == 1, there are two more header fields:
+  #
+  # 1 byte: "attributes" (flags for compression, codec etc)
+  # 4 byte big-endian int: CRC32 checksum of the payload
+  #
+  # All following bytes are the payload.
   class Message
 
     MAGIC_IDENTIFIER_DEFAULT = 0
-    MESSAGE_HEADER_FORMAT = 'NCN'.freeze
+    BASIC_MESSAGE_HEADER = 'NC'.freeze
+    VERSION_0_HEADER = 'N'.freeze
+    VERSION_1_HEADER = 'CN'.freeze
 
     attr_accessor :magic, :checksum, :payload
 
@@ -40,9 +54,22 @@ module Kafka
     end
 
     def self.parse_from(binary)
-      size, magic, checksum = binary.unpack(MESSAGE_HEADER_FORMAT)
-      payload  = binary[9, size] # 5 = 1 + 4 is Magic + Checksum
-      Kafka::Message.new(payload, magic, checksum)
+      size, magic = binary.unpack(BASIC_MESSAGE_HEADER)
+      case magic
+      when 0
+        checksum = binary[5, 4].unpack(VERSION_0_HEADER).shift # 5 = sizeof(length) + sizeof(magic)
+        payload = binary[9, size] # 9 = sizeof(length) + sizeof(magic) + sizeof(checksum)
+        Kafka::Message.new(payload, magic, checksum)
+
+      when 1
+        attributes, checksum = binary[5, 5].unpack(VERSION_1_HEADER)
+        payload = binary[10, size] # 10 = sizeof(length) + sizeof(magic) + sizeof(attrs) + sizeof(checksum)
+        # TODO interpret attributes
+        Kafka::Message.new(payload, magic, checksum)
+
+      else
+        raise "Unsupported Kafka message version: magic number #{magic}"
+      end
     end
   end
 end


### PR DESCRIPTION
The message parser currently assumes that messages always have the magic byte set to 0. However, the Java producer of Kafka 0.7.0 generates messages with magic == 1.

Currently, the parser doesn't even check the value of the magic byte, and just assumes the version 0 format. Thus the message is parsed incorrectly (the last byte of the CRC32 is added as the first byte of the payload, and the CRC32 doesn't match).

This patch adds basic support for version 1. It doesn't yet interpret the value of the attributes byte (that would be a useful addition for the future).
