### PR TITLE
Fix a warning about top-level constant reference while running the specs

### DIFF
--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -25,7 +25,7 @@ describe Consumer do
   describe "Kafka Consumer" do
 
     it "should have a Kafka::RequestType::FETCH" do
-      Consumer::Kafka::RequestType::FETCH.should eql(1)
+      Kafka::RequestType::FETCH.should eql(1)
       @consumer.should respond_to(:request_type)
     end
 


### PR DESCRIPTION
Just a little tweak
