### PR TITLE
Added Snappy compression

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in foo.gemspec
+gemspec
+
+gem "rake"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ and is used in production at wooga.
 You need to have access to your Kafka instance and be able to connect through TCP. 
 You can obtain a copy and instructions on how to setup kafka at http://incubator.apache.org/kafka/
 
+To make Snappy compression available, add
+
+    gem "snappy", "0.0.4", :git => "git://github.com/watersofoblivion/snappy.git", :branch => "snappy-streaming"
+
+to your Gemfile.
 
 ## Installation
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,35 +19,7 @@ require 'rubygems/specification'
 require 'date'
 require 'rspec/core/rake_task'
 
-spec = Gem::Specification.new do |s|
-  s.name = %q{kafka-rb}
-  s.version = "0.0.11"
-
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Alejandro Crosa", "Stefan Mees", "Tim Lossen", "Liam Stewart"]
-  s.autorequire = %q{kafka-rb}
-  s.date = Time.now.strftime("%Y-%m-%d")
-  s.description = %q{kafka-rb allows you to produce and consume messages using the Kafka distributed publish/subscribe messaging service.}
-  s.extra_rdoc_files = ["LICENSE"]
-  s.files = ["LICENSE", "README.md", "Rakefile"] + Dir.glob("lib/**/*.rb")
-  s.test_files = Dir.glob("spec/**/*.rb")
-  s.homepage = %q{http://github.com/acrosa/kafka-rb}
-  s.require_paths = ["lib"]
-  s.summary = %q{A Ruby client for the Kafka distributed publish/subscribe messaging service}
-
-  if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<rspec>, [">= 0"])
-    else
-      s.add_dependency(%q<rspec>, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<rspec>, [">= 0"])
-  end
-end
+spec = eval(File.open("kafka-rb.gemspec", "r").read)
 
 Gem::PackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec
@@ -56,12 +28,6 @@ end
 desc "install the gem locally"
 task :install => [:package] do
   sh %{sudo gem install pkg/#{GEM}-#{GEM_VERSION}}
-end
-
-desc "Run all examples with RCov"
-RSpec::Core::RakeTask.new(:rcov) do |t|
-  t.pattern = FileList['spec/**/*_spec.rb']
-  t.rcov = true
 end
 
 desc "Run specs"

--- a/kafka-rb.gemspec
+++ b/kafka-rb.gemspec
@@ -1,0 +1,29 @@
+Gem::Specification.new do |s|
+  s.name = %q{kafka-rb}
+  s.version = "0.0.12"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.authors = ["Alejandro Crosa", "Stefan Mees", "Tim Lossen", "Liam Stewart"]
+  s.autorequire = %q{kafka-rb}
+  s.date = Time.now.strftime("%Y-%m-%d")
+  s.description = %q{kafka-rb allows you to produce and consume messages using the Kafka distributed publish/subscribe messaging service.}
+  s.extra_rdoc_files = ["LICENSE"]
+  s.files = ["LICENSE", "README.md", "Rakefile"] + Dir.glob("lib/**/*.rb")
+  s.test_files = Dir.glob("spec/**/*.rb")
+  s.homepage = %q{http://github.com/acrosa/kafka-rb}
+  s.require_paths = ["lib"]
+  s.summary = %q{A Ruby client for the Kafka distributed publish/subscribe messaging service}
+
+  if s.respond_to? :specification_version then
+    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
+    s.specification_version = 3
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_development_dependency(%q<rspec>, [">= 0"])
+    else
+      s.add_dependency(%q<rspec>, [">= 0"])
+    end
+  else
+    s.add_dependency(%q<rspec>, [">= 0"])
+  end
+end

--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -14,8 +14,12 @@
 # limitations under the License.
 require 'socket'
 require 'zlib'
-if RUBY_VERSION[0,3] == "1.8"
-  require 'iconv'
+require "stringio"
+
+begin
+  require 'snappy'
+rescue LoadError
+  nil
 end
 
 require File.join(File.dirname(__FILE__), "kafka", "io")

--- a/lib/kafka/encoder.rb
+++ b/lib/kafka/encoder.rb
@@ -15,22 +15,12 @@
 
 module Kafka
   module Encoder
-    def self.message(message)
-      payload = \
-        if RUBY_VERSION[0,3] == "1.8"  # Use old iconv on Ruby 1.8 for encoding
-          Iconv.new('UTF-8//IGNORE', 'UTF-8').iconv(message.payload.to_s)
-        else
-          message.payload.to_s.force_encoding(Encoding::ASCII_8BIT)
-        end
-      data = [message.magic].pack("C") + [message.calculate_checksum].pack("N") + payload
-
-      [data.length].pack("N") + data
+    def self.message(message, compression = Message::NO_COMPRESSION)
+      message.encode(compression)
     end
 
-    def self.message_block(topic, partition, messages)
-      message_set = Array(messages).collect { |message|
-        self.message(message)
-      }.join("")
+    def self.message_block(topic, partition, messages, compression)
+      message_set = message_set(messages, compression)
 
       topic     = [topic.length].pack("n") + topic
       partition = [partition].pack("N")
@@ -39,16 +29,24 @@ module Kafka
       return topic + partition + messages
     end
 
-    def self.produce(topic, partition, messages)
+    def self.message_set(messages, compression)
+      message_set = Array(messages).collect { |message|
+        self.message(message)
+      }.join("")
+      message_set = self.message(Message.new(message_set), compression) unless compression == Message::NO_COMPRESSION
+      message_set
+    end
+
+    def self.produce(topic, partition, messages, compression = Message::NO_COMPRESSION)
       request = [RequestType::PRODUCE].pack("n")
-      data = request + self.message_block(topic, partition, messages)
+      data = request + self.message_block(topic, partition, messages, compression)
 
       return [data.length].pack("N") + data
     end
 
-    def self.multiproduce(producer_requests)
+    def self.multiproduce(producer_requests, compression = Message::NO_COMPRESSION)
       part_set = Array(producer_requests).map { |req|
-        self.message_block(req.topic, req.partition, req.messages)
+        self.message_block(req.topic, req.partition, req.messages, compression)
       }
 
       request = [RequestType::MULTIPRODUCE].pack("n")

--- a/lib/kafka/io.rb
+++ b/lib/kafka/io.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 module Kafka
   module IO
-    attr_accessor :socket, :host, :port
+    attr_accessor :socket, :host, :port, :compression
 
     HOST = "localhost"
     PORT = 9092

--- a/lib/kafka/message.rb
+++ b/lib/kafka/message.rb
@@ -33,6 +33,10 @@ module Kafka
   class Message
 
     MAGIC_IDENTIFIER_DEFAULT = 0
+    MAGIC_IDENTIFIER_COMPRESSION = 1
+    NO_COMPRESSION = 0
+    GZIP_COMPRESSION = 1
+    SNAPPY_COMPRESSION = 2
     BASIC_MESSAGE_HEADER = 'NC'.freeze
     VERSION_0_HEADER = 'N'.freeze
     VERSION_1_HEADER = 'CN'.freeze
@@ -41,9 +45,10 @@ module Kafka
     attr_accessor :magic, :checksum, :payload
 
     def initialize(payload = nil, magic = MAGIC_IDENTIFIER_DEFAULT, checksum = nil)
-      self.magic    = magic
-      self.payload  = payload || ""
-      self.checksum = checksum || self.calculate_checksum
+      self.magic       = magic
+      self.payload     = payload || ""
+      self.checksum    = checksum || self.calculate_checksum
+      @compression = NO_COMPRESSION
     end
 
     def calculate_checksum
@@ -66,7 +71,7 @@ module Kafka
         break if bytes_processed + message_size + 4 > data.length # message is truncated
 
         case magic
-        when 0
+        when MAGIC_IDENTIFIER_DEFAULT
           # |  0  |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9      ...
           # |                       |     |                       |
           # |      message_size     |magic|        checksum       | payload ...
@@ -75,7 +80,7 @@ module Kafka
           payload  = data[bytes_processed + 9, payload_size]
           messages << Kafka::Message.new(payload, magic, checksum)
 
-        when 1
+        when MAGIC_IDENTIFIER_COMPRESSION
           # |  0  |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10      ...
           # |                       |     |     |                       |
           # |         size          |magic|attrs|        checksum       | payload ...
@@ -84,18 +89,22 @@ module Kafka
           payload = data[bytes_processed + 10, payload_size]
 
           case attributes & COMPRESSION_CODEC_MASK
-          when 0 # a single uncompressed message
+          when NO_COMPRESSION # a single uncompressed message
             messages << Kafka::Message.new(payload, magic, checksum)
-          when 1 # a gzip-compressed message set -- parse recursively
+          when GZIP_COMPRESSION # a gzip-compressed message set -- parse recursively
             uncompressed = Zlib::GzipReader.new(StringIO.new(payload)).read
             message_set = parse_from(uncompressed)
             raise 'malformed compressed message' if message_set.size != uncompressed.size
             messages.concat(message_set.messages)
+          when SNAPPY_COMPRESSION # a snappy-compresses message set -- parse recursively
+            ensure_snappy! do
+              uncompressed = Snappy::Reader.new(StringIO.new(payload)).read
+              message_set = parse_from(uncompressed)
+              raise 'malformed compressed message' if message_set.size != uncompressed.size
+              messages.concat(message_set.messages)
+            end
           else
             # https://cwiki.apache.org/confluence/display/KAFKA/Compression
-            # claims that 2 is for Snappy compression, but Kafka's Scala client
-            # implementation doesn't seem to support it yet, so I don't have
-            # a reference implementation to test against.
             raise "Unsupported Kafka compression codec: #{attributes & COMPRESSION_CODEC_MASK}"
           end
 
@@ -108,10 +117,93 @@ module Kafka
 
       MessageSet.new(bytes_processed, messages)
     end
-  end
 
-  # Encapsulates a list of Kafka messages (as Kafka::Message objects in the
-  # +messages+ attribute) and their total serialized size in bytes (the +size+
-  # attribute).
-  class MessageSet < Struct.new(:size, :messages); end
+    def encode(compression = NO_COMPRESSION)
+      @compression = compression
+
+      self.payload = asciify_payload
+      self.payload = compress_payload if compression?
+
+      data = magic_and_compression + [calculate_checksum].pack("N") + payload
+      [data.length].pack("N") + data
+    end
+
+
+    # Encapsulates a list of Kafka messages (as Kafka::Message objects in the
+    # +messages+ attribute) and their total serialized size in bytes (the +size+
+    # attribute).
+    class MessageSet < Struct.new(:size, :messages); end
+
+    def self.ensure_snappy!
+      if Object.const_defined? "Snappy"
+        yield
+      else
+        fail "Snappy not available!"
+      end
+    end
+
+    def ensure_snappy! &block
+      self.class.ensure_snappy! &block
+    end
+
+    private
+
+    attr_reader :compression
+
+    def compression?
+      compression != NO_COMPRESSION
+    end
+
+    def magic_and_compression
+      if compression?
+        [MAGIC_IDENTIFIER_COMPRESSION, compression].pack("CC")
+      else
+        [MAGIC_IDENTIFIER_DEFAULT].pack("C")
+      end
+    end
+
+    def asciify_payload
+      if RUBY_VERSION[0, 3] == "1.8"
+        payload
+      else
+        payload.to_s.force_encoding(Encoding::ASCII_8BIT)
+      end
+    end
+
+    def compress_payload
+      case compression
+        when GZIP_COMPRESSION
+          gzip
+        when SNAPPY_COMPRESSION
+          snappy
+      end
+    end
+
+    def gzip
+      with_buffer do |buffer|
+        gz = Zlib::GzipWriter.new buffer, nil, nil
+        gz.write payload
+        gz.close
+      end
+    end
+
+    def snappy
+      ensure_snappy! do
+        with_buffer do |buffer|
+          Snappy::Writer.new buffer do |w|
+            w << payload
+          end
+        end
+      end
+    end
+
+    def with_buffer
+      buffer = StringIO.new
+      buffer.set_encoding Encoding::ASCII_8BIT unless RUBY_VERSION =~ /^1\.8/
+      yield buffer if block_given?
+      buffer.rewind
+      buffer.string
+    end
+  end
 end
+

--- a/lib/kafka/multi_producer.rb
+++ b/lib/kafka/multi_producer.rb
@@ -19,16 +19,17 @@ module Kafka
     def initialize(options={})
       self.host = options[:host] || HOST
       self.port = options[:port] || PORT
+      self.compression = options[:compression] || Message::NO_COMPRESSION
       self.connect(self.host, self.port)
     end
 
     def send(topic, messages, options={})
       partition = options[:partition] || 0
-      self.write(Encoder.produce(topic, partition, messages))
+      self.write(Encoder.produce(topic, partition, messages, compression))
     end
 
     def multi_send(producer_requests)
-      self.write(Encoder.multiproduce(producer_requests))
+      self.write(Encoder.multiproduce(producer_requests, compression))
     end
   end
 end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -20,15 +20,16 @@ module Kafka
     attr_accessor :topic, :partition
 
     def initialize(options = {})
-      self.topic     = options[:topic]      || "test"
-      self.partition = options[:partition]  || 0
-      self.host      = options[:host]       || HOST
-      self.port      = options[:port]       || PORT
+      self.topic       = options[:topic]      || "test"
+      self.partition   = options[:partition]  || 0
+      self.host        = options[:host]       || HOST
+      self.port        = options[:port]       || PORT
+      self.compression = options[:compression] || Message::NO_COMPRESSION
       self.connect(self.host, self.port)
     end
 
     def send(messages)
-      self.write(Encoder.produce(self.topic, self.partition, messages))
+      self.write(Encoder.produce(self.topic, self.partition, messages, compression))
     end
 
     def batch(&block)

--- a/spec/kafka_spec.rb
+++ b/spec/kafka_spec.rb
@@ -15,7 +15,6 @@
 require File.dirname(__FILE__) + '/spec_helper'
 
 describe Kafka do
-
   before(:each) do
   end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -16,6 +16,10 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 describe Message do
 
+  def pack_v1_message bytes, attributes
+    [6 + bytes.length, 1, attributes, Zlib.crc32(bytes), bytes].pack "NCCNa*"
+  end
+
   before(:each) do
     @message = Message.new
   end
@@ -120,7 +124,36 @@ describe Message do
       message.payload.should == 'abracadabra'
     end
 
-    it "should recursively parse nested compressed messages" do
+    if Object.const_defined? "Snappy"
+      it "should parse a snappy-compressed message" do
+        cleartext = "abracadabra"
+        bytes = pack_v1_message cleartext, 0
+        compressed = Snappy.deflate(bytes)
+        bytes = pack_v1_message compressed, 2
+        message = Message.parse_from(bytes).messages.first
+        message.should be_valid
+        message.payload.should == cleartext
+      end
+
+      it "should recursively parse nested snappy compressed messages" do
+        uncompressed = pack_v1_message('abracadabra', 0)
+        uncompressed << pack_v1_message('foobar', 0)
+        compressed = pack_v1_message(Snappy.deflate(uncompressed), 2)
+        messages = Message.parse_from(compressed).messages
+        messages.map(&:payload).should == ['abracadabra', 'foobar']
+        messages.map(&:valid?).should == [true, true]
+      end
+
+      it "should support a mixture of snappy compressed and uncompressed messages" do
+        bytes = pack_v1_message(Snappy.deflate(pack_v1_message("compressed", 0)), 2)
+        bytes << pack_v1_message('uncompressed', 0)
+        messages = Message.parse_from(bytes).messages
+        messages.map(&:payload).should == ["compressed", "uncompressed"]
+        messages.map(&:valid?).should == [true, true]
+      end
+    end
+
+    it "should recursively parse nested gzip compressed messages" do
       uncompressed = [17, 1, 0, 401275319, 'abracadabra'].pack('NCCNa*')
       uncompressed << [12, 1, 0, 2666930069, 'foobar'].pack('NCCNa*')
       compressed_io = StringIO.new('')
@@ -132,7 +165,7 @@ describe Message do
       messages.map(&:valid?).should == [true, true]
     end
 
-    it "should support a mixture of compressed and uncompressed messages" do
+    it "should support a mixture of gzip compressed and uncompressed messages" do
       compressed = 'H4sIAG0LI1AAA2NgYBBkZBB/9XN7YlJRYnJiCogCAH9lueQVAAAA'.unpack('m*').shift
       bytes = [45, 1, 1, 1303540914, compressed].pack('NCCNa*')
       bytes << [11, 1, 0, 907060870, 'hello'].pack('NCCNa*')
@@ -142,10 +175,53 @@ describe Message do
     end
 
     it "should raise an error if the compression codec is not supported" do
-      bytes = [6, 1, 2, 0, ''].pack('NCCNa*') # 2 = Snappy codec
+      bytes = [6, 1, 3, 0, ''].pack('NCCNa*') # 3 = some unknown future compression codec
       lambda {
         Kafka::Message.parse_from(bytes)
       }.should raise_error(RuntimeError, /Unsupported Kafka compression codec/)
+    end
+  end
+
+  describe "#ensure_snappy!" do
+    let(:message) { Kafka::Message.new }
+    before { Kafka::Message.instance_variable_set :@snappy, nil }
+
+    subject { message.ensure_snappy! { 42 } }
+
+    if Object.const_defined? "Snappy"
+      context "when snappy is available" do
+        before { Object.stub! :const_defined? => true }
+        it { should == 42 }
+      end
+    end
+
+    context "when snappy is not available" do
+      before { Object.stub! :const_defined? => false }
+
+      it "raises an error" do
+        expect { message.ensure_snappy! { 42 } }.to raise_error
+      end
+    end
+  end
+
+  describe ".ensure_snappy!" do
+    before { Kafka::Message.instance_variable_set :@snappy, nil }
+
+    subject { Kafka::Message.ensure_snappy! { 42 } }
+
+    if Object.const_defined? "Snappy"
+      context "when snappy is available" do
+        before { Object.stub! :const_defined? => true }
+        it { should == 42 }
+      end
+    end
+
+    context "when snappy is not available" do
+      before { Object.stub! :const_defined? => false }
+
+      it "raises an error" do
+        expect { Kafka::Message.ensure_snappy! { 42 } }.to raise_error
+      end
     end
   end
 end

--- a/spec/producer_request_spec.rb
+++ b/spec/producer_request_spec.rb
@@ -32,7 +32,7 @@ describe ProducerRequest do
   end
 
   it "can use a user-specified partition" do
-    req = described_class.new("topic", message, partition: 42)
+    req = described_class.new("topic", message, :partition => 42)
     req.partition.should == 42
   end
 end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -30,6 +30,12 @@ describe Producer do
       @producer.should respond_to(:partition)
     end
 
+    it "should have compression" do
+      @producer.should respond_to :compression
+      Producer.new(:compression => 1).compression.should == 1
+      Producer.new.compression.should == 0
+    end
+
     it "should set a topic and partition on initialize" do
       @producer = Producer.new({ :host => "localhost", :port => 9092, :topic => "testing" })
       @producer.topic.should eql("testing")


### PR DESCRIPTION
This branch adds streaming snappy compression support that is wire compatible with Java.

Currently this branch relies on a fork of the ruby snappy library. A pull request has been submitted to that project. https://github.com/watersofoblivion/snappy/tree/snappy-streaming 

We've had both of these in production for months without issue.
