### PR TITLE
Remove unnecessary code in Kafka::Producer#batch

### DIFF
--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -36,7 +36,6 @@ module Kafka
       batch = Kafka::Batch.new
       block.call( batch )
       self.send(batch.messages)
-      batch.messages.clear
     end
   end
 end


### PR DESCRIPTION
This pull request removes unnecessary code in `Kafka::Producer#batch` method. Since the method always creates a new Kafka::Batch instance at the beginning, it would not be necessary to clear its instance variable `batch.messages` at the end.
