### PR TITLE
Rename producer/multi-producer methods to push

### DIFF
--- a/lib/kafka/multi_producer.rb
+++ b/lib/kafka/multi_producer.rb
@@ -23,12 +23,12 @@ module Kafka
       self.connect(self.host, self.port)
     end
 
-    def send(topic, messages, options={})
+    def push(topic, messages, options={})
       partition = options[:partition] || 0
       self.write(Encoder.produce(topic, partition, messages, compression))
     end
 
-    def multi_send(producer_requests)
+    def multi_push(producer_requests)
       self.write(Encoder.multiproduce(producer_requests, compression))
     end
   end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -28,14 +28,14 @@ module Kafka
       self.connect(self.host, self.port)
     end
 
-    def send(messages)
+    def push(messages)
       self.write(Encoder.produce(self.topic, self.partition, messages, compression))
     end
 
     def batch(&block)
       batch = Kafka::Batch.new
       block.call( batch )
-      self.send(batch.messages)
+      push(batch.messages)
       batch.messages.clear
     end
   end

--- a/spec/multi_producer_spec.rb
+++ b/spec/multi_producer_spec.rb
@@ -38,7 +38,7 @@ describe MultiProducer do
       encoded = Kafka::Encoder.produce("test", 0, message)
 
       subject.should_receive(:write).with(encoded).and_return(encoded.length)
-      subject.send("test", message, :partition => 0).should == encoded.length
+      subject.push("test", message, :partition => 0).should == encoded.length
     end
 
     it "sends multiple messages" do
@@ -50,7 +50,7 @@ describe MultiProducer do
       encoded = Encoder.multiproduce(reqs)
 
       subject.should_receive(:write).with(encoded).and_return(encoded.length)
-      subject.multi_send(reqs).should == encoded.length
+      subject.multi_push(reqs).should == encoded.length
     end
 
     it "should compress messages" do
@@ -60,7 +60,7 @@ describe MultiProducer do
 
       encoded = Encoder.produce("test", 0, messages[0])
       Encoder.should_receive(:produce).with("test", 0, messages[0], subject.compression).and_return encoded
-      subject.send("test", messages[0], :partition => 0)
+      subject.push("test", messages[0], :partition => 0)
 
       reqs = [
           Kafka::ProducerRequest.new("topic", messages[0]),
@@ -68,7 +68,7 @@ describe MultiProducer do
       ]
       encoded = Encoder.multiproduce(reqs)
       Encoder.should_receive(:multiproduce).with(reqs, subject.compression)
-      subject.multi_send(reqs)
+      subject.multi_push(reqs)
     end
   end
 end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -54,14 +54,14 @@ describe Producer do
   it "should send messages" do
     @producer.should_receive(:write).and_return(32)
     message = Kafka::Message.new("ale")
-    @producer.send(message).should eql(32)
+    @producer.push(message).should eql(32)
   end
 
   describe "Message Batching" do
     it "should batch messages and send them at once" do
       message1 = Kafka::Message.new("one")
       message2 = Kafka::Message.new("two")
-      @producer.should_receive(:send).with([message1, message2]).exactly(:once).and_return(nil)
+      @producer.should_receive(:push).with([message1, message2]).exactly(:once).and_return(nil)
       @producer.batch do |messages|
         messages << message1
         messages << message2


### PR DESCRIPTION
Send is problematic in ruby because it is defined on all objects as a
way to dynamically send method calls (messages). You do not want to have
any methods in your interface that define send.

This would resolve #18
