### PR TITLE
Updates to fix issue when reading snappy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ kafka-rb allows you to produce and consume messages to / from the Kafka distribu
 This is an improved version of the original Ruby client written by Alejandro Crosa, 
 and is used in production at wooga.
 
+## Ubuntu Pre-install
+
+    apt-get install build-essential gcc g++ liblzo2-dev
+    apt-get install ruby1.9.1-dev
+    apt-get install libsnappy1 libsnappy-dev
+
 ## Requirements
 You need to have access to your Kafka instance and be able to connect through TCP. 
 You can obtain a copy and instructions on how to setup kafka at http://incubator.apache.org/kafka/
@@ -18,12 +24,6 @@ to your Gemfile.
     sudo gem install kafka-rb
 
 (should work fine with JRuby, Ruby 1.8 and 1.9)
-
-## Ubuntu Pre Install
-
-    apt-get install build-essential gcc g++ liblzo2-dev
-    apt-get install ruby1.9.1-dev
-    apt-get install libsnappy1 libsnappy-dev
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ to your Gemfile.
 
 (should work fine with JRuby, Ruby 1.8 and 1.9)
 
+## Ubuntu Pre Install
+
+    apt-get install build-essential gcc g++ liblzo2-dev
+    apt-get install ruby1.9.1-dev
+    apt-get install libsnappy1 libsnappy-dev
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can obtain a copy and instructions on how to setup kafka at http://incubator
 
 To make Snappy compression available, add
 
-    gem "snappy", "0.0.4", :git => "git://github.com/watersofoblivion/snappy.git", :branch => "snappy-streaming"
+    gem "snappy"
 
 to your Gemfile.
 

--- a/README.md
+++ b/README.md
@@ -110,13 +110,16 @@ to your Gemfile.
     
     puts "Master listener started..."
     
-    threads = []
-    15.times do | p |
-      threads[p] = Thread.new{ listen(p) }
+    # listen to 16 partitions on kafka 
+    # (be sure to configure to size of your kafka cluster)
+    subscribers = []
+    15.times do | partition_index |
+      subscribers[p] = Thread.new{ subscribe(partition_index) }
     end
     
-    threads.each do | t |
-      t.join
+    # endless loop pulling messages
+    subscribers.each do | sub |
+      sub.join
     end
 
 ### Using the cli

--- a/kafka-rb.gemspec
+++ b/kafka-rb.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{kafka-rb}
-  s.version = "0.0.15"
+  s.version = "0.0.16"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Alejandro Crosa", "Stefan Mees", "Tim Lossen", "Liam Stewart"]

--- a/lib/kafka/message.rb
+++ b/lib/kafka/message.rb
@@ -100,7 +100,6 @@ module Kafka
             ensure_snappy! do
               uncompressed = Snappy::Reader.new(StringIO.new(payload)).read
               message_set = parse_from(uncompressed)
-              raise 'malformed compressed message' if message_set.size != uncompressed.size
               messages.concat(message_set.messages)
             end
           else


### PR DESCRIPTION
Fixes
* SNAPPY compression check was invalid, messages are perfectly readable without this check - we run a system that does over 1 billion compressed avro kafka messages and it kept failing at this line for no traceable reason. Removing the line and re-running processed all messages successfully.

Docs
* Updated docs for more practical examples (kafka with multiple partitions)
* Updated docs to remove dependency on branch
* Updated docs to include dependencies (at least on ubuntu)